### PR TITLE
fixed rich comparison methods for session

### DIFF
--- a/sessionsaver/store.py
+++ b/sessionsaver/store.py
@@ -35,6 +35,12 @@ class Session(object):
     def __lt__(self, session):
         return (self.name.lower() < session.name.lower())
 
+    def __eq__(self, session):
+        return (self.name.lower() == session.name.lower())
+
+    def __ne__(self, session):
+        return (self.name.lower() != session.name.lower())
+
     def add_file(self, filename):
         self.files.append(Gio.file_new_for_uri(filename))
 


### PR DESCRIPTION
(reposted from #7 because of an accident with git filter-branch)

Porting Session Saver to Python 3 removed the `__cmp__` method for comparing objects and replaced them with the rich comparison methods like `__lt__`. However, during the port, `__eq__` wasn't added to the Session class, which meant that identically named sessions weren't considered equal. This meant that sessions would never be changed, leading them to be duplicated:
![session_duplicate](https://cloud.githubusercontent.com/assets/1497826/3867388/c4e6e85a-1ffc-11e4-871e-e4f1bffd09a5.png)
This adds the `__eq__` method in, and the `__ne__` method just for completeness.
